### PR TITLE
Fixed not using SqlParameter for table name when listing table primary keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Updated dependencies, fixing issue in uploading string typed big integers e.g. `"9223372036854775807"`
-
-
+- Fixed bug in Sql Server implementation for column/table names containing single quotes
 
 ## [0.11.0] - 2020-02-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Updated dependencies, fixing issue in uploading string typed big integers e.g. `"9223372036854775807"`
-- Fixed bug in Sql Server implementation for column/table names containing single quotes
+- Fixed table creation and column discovery when column/table names containing backticks and/or single quotes
 
 ## [0.11.0] - 2020-02-27
 

--- a/Implementations/FAnsi.Implementations.MicrosoftSQL/MicrosoftSQLTableHelper.cs
+++ b/Implementations/FAnsi.Implementations.MicrosoftSQL/MicrosoftSQLTableHelper.cs
@@ -155,10 +155,15 @@ sys.parameters.precision AS PRECISION
 sys.parameters 
 join
 sys.types on sys.parameters.user_type_id = sys.types.user_type_id
-where object_id = OBJECT_ID('" + GetObjectName(discoveredTableValuedFunction) + "')";
+where object_id = OBJECT_ID(@tableName)";
 
             using (DbCommand cmd = discoveredTableValuedFunction.GetCommand(query, connection))
             {
+                var p = cmd.CreateParameter();
+                p.ParameterName = "@tableName";
+                p.Value = GetObjectName(discoveredTableValuedFunction);
+                cmd.Parameters.Add(p);
+
                 cmd.Transaction = transaction;
 
                 using (var r = cmd.ExecuteReader())
@@ -375,7 +380,7 @@ where object_id = OBJECT_ID('" + GetObjectName(discoveredTableValuedFunction) + 
         {
             List<string> toReturn = new List<string>();
 
-            string query = String.Format(@"SELECT i.name AS IndexName, 
+            string query = @"SELECT i.name AS IndexName, 
 OBJECT_NAME(ic.OBJECT_ID) AS TableName, 
 COL_NAME(ic.OBJECT_ID,ic.column_id) AS ColumnName, 
 c.is_identity
@@ -384,11 +389,16 @@ INNER JOIN sys.index_columns AS ic
 INNER JOIN sys.columns AS c ON ic.object_id = c.object_id AND ic.column_id = c.column_id 
 ON i.OBJECT_ID = ic.OBJECT_ID 
 AND i.index_id = ic.index_id 
-WHERE (i.is_primary_key = 1) AND ic.OBJECT_ID = OBJECT_ID('{0}')
-ORDER BY OBJECT_NAME(ic.OBJECT_ID), ic.key_ordinal", GetObjectName(table));
+WHERE (i.is_primary_key = 1) AND ic.OBJECT_ID = OBJECT_ID(@tableName)
+ORDER BY OBJECT_NAME(ic.OBJECT_ID), ic.key_ordinal";
 
             using (DbCommand cmd = table.GetCommand(query, con.Connection))
             {
+                var p = cmd.CreateParameter();
+                p.ParameterName = "@tableName";
+                p.Value = GetObjectName(table);
+                cmd.Parameters.Add(p);
+
                 cmd.Transaction = con.Transaction;
                 using(DbDataReader r = cmd.ExecuteReader())
                 {

--- a/Implementations/FAnsi.Implementations.MySql/MySqlQuerySyntaxHelper.cs
+++ b/Implementations/FAnsi.Implementations.MySql/MySqlQuerySyntaxHelper.cs
@@ -4,6 +4,7 @@ using FAnsi.Discovery;
 using FAnsi.Discovery.QuerySyntax;
 using FAnsi.Implementations.MySql.Aggregation;
 using FAnsi.Implementations.MySql.Update;
+using FAnsi.Naming;
 
 namespace FAnsi.Implementations.MySql
 {
@@ -24,16 +25,25 @@ namespace FAnsi.Implementations.MySql
 
         public override string EnsureWrappedImpl(string databaseOrTableName)
         {
-            return "`" + GetRuntimeName(databaseOrTableName) + "`";
+            return "`" + GetRuntimeNameWithDoubledBackticks(databaseOrTableName) + "`";
         }
 
+        /// <summary>
+        /// Returns the runtime name of the string with all backticks escaped (but resulting string is not wrapped in backticks itself)
+        /// </summary>
+        /// <param name="s"></param>
+        /// <returns></returns>
+        private string GetRuntimeNameWithDoubledBackticks(string s)
+        {
+            return GetRuntimeName(s).Replace("`","``");
+        }
         public override string EnsureFullyQualified(string databaseName, string schema, string tableName)
         {
             //if there is no schema address it as db..table (which is the same as db.dbo.table in Microsoft SQL Server)
             if (!string.IsNullOrWhiteSpace(schema))
                 throw new NotSupportedException("Schema (e.g. .dbo. not supported by MySql)");
 
-            return "`" + GetRuntimeName(databaseName) + "`" + DatabaseTableSeparator + "`" + GetRuntimeName(tableName) + "`";
+            return "`" + GetRuntimeNameWithDoubledBackticks(databaseName) + "`" + DatabaseTableSeparator + "`" + GetRuntimeNameWithDoubledBackticks(tableName) + "`";
         }
 
         public override TopXResponse HowDoWeAchieveTopX(int x)

--- a/Implementations/FAnsi.Implementations.PostgreSql/PostgreSqlTableHelper.cs
+++ b/Implementations/FAnsi.Implementations.PostgreSql/PostgreSqlTableHelper.cs
@@ -87,7 +87,7 @@ namespace FAnsi.Implementations.PostgreSql
             format_type(pg_attribute.atttypid, pg_attribute.atttypmod) 
             FROM pg_index, pg_class, pg_attribute 
             WHERE 
-            pg_class.oid = '{table.GetFullyQualifiedName()}'::regclass AND 
+            pg_class.oid = @tableName::regclass AND 
                 indrelid = pg_class.oid AND  
             pg_attribute.attrelid = pg_class.oid AND 
             pg_attribute.attnum = any(pg_index.indkey)
@@ -98,6 +98,11 @@ namespace FAnsi.Implementations.PostgreSql
             using (DbCommand cmd = table.GetCommand(query, con.Connection))
             {
                 cmd.Transaction = con.Transaction;
+
+                var p = cmd.CreateParameter();
+                p.ParameterName = "@tableName";
+                p.Value = table.GetFullyQualifiedName();
+                cmd.Parameters.Add(p);
 
                 using(DbDataReader r = cmd.ExecuteReader())
                 {

--- a/Tests/FAnsiTests/Query/QuerySyntaxHelperTests.cs
+++ b/Tests/FAnsiTests/Query/QuerySyntaxHelperTests.cs
@@ -170,5 +170,16 @@ namespace FAnsiTests.Query
                     throw new ArgumentOutOfRangeException(nameof(dbType), dbType, null);
             }
         }
+        
+        [Test]
+        public void Test_GetFullyQualifiedName_BacktickMySql()
+        {
+            ImplementationManager.Load(new DirectoryInfo(TestContext.CurrentContext.TestDirectory));
+            var syntaxHelper = ImplementationManager.GetImplementation(DatabaseType.MySql).GetQuerySyntaxHelper();
+
+            //when names have backticks the correct response is to double back tick them
+            Assert.AreEqual("`ff``ff`",syntaxHelper.EnsureWrapped("ff`ff"));
+            Assert.AreEqual("`d``b`.`ta``ble`",syntaxHelper.EnsureFullyQualified("d`b",null,"ta`ble"));
+        }
     }
 }

--- a/Tests/FAnsiTests/Query/QuerySyntaxHelperTests.cs
+++ b/Tests/FAnsiTests/Query/QuerySyntaxHelperTests.cs
@@ -180,6 +180,9 @@ namespace FAnsiTests.Query
             //when names have backticks the correct response is to double back tick them
             Assert.AreEqual("`ff``ff`",syntaxHelper.EnsureWrapped("ff`ff"));
             Assert.AreEqual("`d``b`.`ta``ble`",syntaxHelper.EnsureFullyQualified("d`b",null,"ta`ble"));
+
+            //runtime name should still be the actual name of the column
+            Assert.AreEqual("ff`ff",syntaxHelper.GetRuntimeName("ff`ff"));
         }
     }
 }

--- a/Tests/FAnsiTests/Table/DiscoverColumnsTests.cs
+++ b/Tests/FAnsiTests/Table/DiscoverColumnsTests.cs
@@ -1,0 +1,31 @@
+﻿using FAnsi;
+using FAnsi.Discovery;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using TypeGuesser;
+
+namespace FAnsiTests.Table
+{
+    class DiscoverColumnsTests : DatabaseTests
+    {
+        [TestCaseSource(typeof(All),nameof(All.DatabaseTypes))]
+        public void DiscoverColumns_BadNames(DatabaseType dbType)
+        {
+            var db = GetTestDatabase(dbType);
+
+            var tbl = db.CreateTable("Fi ; '`sh",new[]
+            {
+                new DatabaseColumnRequest("Da'   ,,;ve",new DatabaseTypeRequest(typeof(string),100)), 
+                new DatabaseColumnRequest("Frrrrr ##' ank",new DatabaseTypeRequest(typeof(int))) 
+            });
+
+            var cols = tbl.DiscoverColumns();
+            Assert.AreEqual(2,cols.Length);
+
+            var col = tbl.DiscoverColumn("Da'   ,,;ve");
+            Assert.AreEqual(100,col.DataType.GetLengthIfString());
+        }
+    }
+}


### PR DESCRIPTION
Upstream fix for issures relating to https://github.com/HicServices/RDMP/issues/66

This allows very dodgy column and table names to be properly handled by DBMS layer.