### PR TITLE
Feature/fix create schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ...
 
+### Fixed
+
+- Fixed bug in CreateSchema (Sql Server) where a schema with the same name already exists.  This bug was introduced in 1.0.3 (only affects repeated calls).
+
 ## [1.0.3] - 2020-08-06
 
 ### Changed

--- a/Implementations/FAnsi.Implementations.MicrosoftSQL/MicrosoftQuerySyntaxHelper.cs
+++ b/Implementations/FAnsi.Implementations.MicrosoftSQL/MicrosoftQuerySyntaxHelper.cs
@@ -134,7 +134,7 @@ namespace FAnsi.Implementations.MicrosoftSQL
                 return EnsureWrapped( GetRuntimeName(databaseName)) + DatabaseTableSeparator + DatabaseTableSeparator + EnsureWrapped(GetRuntimeName(tableName));
 
             //there is a schema so add it in
-            return EnsureWrapped(databaseName) + DatabaseTableSeparator + schema + DatabaseTableSeparator + EnsureWrapped( GetRuntimeName(tableName));
+            return EnsureWrapped(GetRuntimeName(databaseName)) + DatabaseTableSeparator + EnsureWrapped(GetRuntimeName(schema)) + DatabaseTableSeparator + EnsureWrapped( GetRuntimeName(tableName));
         }
 
         public override string EnsureFullyQualified(string databaseName, string schema, string tableName, string columnName, bool isTableValuedFunction = false)

--- a/Implementations/FAnsi.Implementations.MicrosoftSQL/MicrosoftSQLDatabaseHelper.cs
+++ b/Implementations/FAnsi.Implementations.MicrosoftSQL/MicrosoftSQLDatabaseHelper.cs
@@ -233,8 +233,8 @@ WHERE type_desc = 'SQL_INLINE_TABLE_VALUED_FUNCTION' OR type_desc = 'SQL_TABLE_V
         public override void CreateSchema(DiscoveredDatabase discoveredDatabase, string name)
         {
             var syntax = discoveredDatabase.Server.GetQuerySyntaxHelper();
-            name = syntax.EnsureWrapped(name);
             var runtimeName = syntax.GetRuntimeName(name);
+            name = syntax.EnsureWrapped(name);
 
             using (var con = discoveredDatabase.Server.GetConnection())
             {

--- a/Implementations/FAnsi.Implementations.MicrosoftSQL/MicrosoftSQLDatabaseHelper.cs
+++ b/Implementations/FAnsi.Implementations.MicrosoftSQL/MicrosoftSQLDatabaseHelper.cs
@@ -234,12 +234,13 @@ WHERE type_desc = 'SQL_INLINE_TABLE_VALUED_FUNCTION' OR type_desc = 'SQL_TABLE_V
         {
             var syntax = discoveredDatabase.Server.GetQuerySyntaxHelper();
             name = syntax.EnsureWrapped(name);
+            var runtimeName = syntax.GetRuntimeName(name);
 
             using (var con = discoveredDatabase.Server.GetConnection())
             {
                 con.Open();
 
-                string sql = $@"if not exists (select 1 from sys.schemas where name = '{name}')
+                string sql = $@"if not exists (select 1 from sys.schemas where name = '{runtimeName}')
 	    EXEC('CREATE SCHEMA {name}')";
 
                 using(var cmd = discoveredDatabase.Server.GetCommand(sql, con))

--- a/Implementations/FAnsi.Implementations.PostgreSql/PostgreSqlDatabaseHelper.cs
+++ b/Implementations/FAnsi.Implementations.PostgreSql/PostgreSqlDatabaseHelper.cs
@@ -149,7 +149,9 @@ namespace FAnsi.Implementations.PostgreSql
             {
                 con.Open();
 
-                string sql = $@"create schema if not exists {name}";
+                var syntax = discoveredDatabase.Server.GetQuerySyntaxHelper();
+                
+                string sql = $@"create schema if not exists {syntax.EnsureWrapped(name)}";
 
                 using(var cmd = discoveredDatabase.Server.GetCommand(sql, con))
                     cmd.ExecuteNonQuery();

--- a/Implementations/FAnsi.Implementations.PostgreSql/PostgreSqlSyntaxHelper.cs
+++ b/Implementations/FAnsi.Implementations.PostgreSql/PostgreSqlSyntaxHelper.cs
@@ -53,7 +53,7 @@ namespace FAnsi.Implementations.PostgreSql
                 return EnsureWrapped(databaseName) + DatabaseTableSeparator + DefaultPostgresSchema + DatabaseTableSeparator + EnsureWrapped(tableName);
 
             //there is a schema so add it in
-            return EnsureWrapped(databaseName) + DatabaseTableSeparator + schema + DatabaseTableSeparator + EnsureWrapped(tableName);
+            return EnsureWrapped(databaseName) + DatabaseTableSeparator + EnsureWrapped(schema) + DatabaseTableSeparator + EnsureWrapped(tableName);
         }
 
         public override string EnsureFullyQualified(string databaseName, string schema, string tableName, string columnName,

--- a/Tests/FAnsiTests/Database/DatabaseLevelTests.cs
+++ b/Tests/FAnsiTests/Database/DatabaseLevelTests.cs
@@ -37,6 +37,7 @@ namespace FAnsiTests.Database
             Assert.DoesNotThrow(()=>db.CreateSchema("Frank"));
             Assert.DoesNotThrow(()=>db.CreateSchema("Frank"));
             Assert.DoesNotThrow(()=>db.CreateSchema("[Frank]"));
+            Assert.DoesNotThrow(()=>db.CreateSchema("[Frank]"));
 
             if (type == DatabaseType.MicrosoftSQLServer)
             {

--- a/Tests/FAnsiTests/Database/DatabaseLevelTests.cs
+++ b/Tests/FAnsiTests/Database/DatabaseLevelTests.cs
@@ -36,8 +36,12 @@ namespace FAnsiTests.Database
 
             Assert.DoesNotThrow(()=>db.CreateSchema("Frank"));
             Assert.DoesNotThrow(()=>db.CreateSchema("Frank"));
-            Assert.DoesNotThrow(()=>db.CreateSchema("[Frank]"));
-            Assert.DoesNotThrow(()=>db.CreateSchema("[Frank]"));
+
+            if(type == DatabaseType.MicrosoftSQLServer)
+            {
+                Assert.DoesNotThrow(()=>db.CreateSchema("[Frank]"));
+                Assert.DoesNotThrow(()=>db.CreateSchema("[Frank]"));
+            }
 
             if (type == DatabaseType.MicrosoftSQLServer)
             {

--- a/Tests/FAnsiTests/Database/DatabaseLevelTests.cs
+++ b/Tests/FAnsiTests/Database/DatabaseLevelTests.cs
@@ -35,6 +35,8 @@ namespace FAnsiTests.Database
             var db = GetTestDatabase(type);
 
             Assert.DoesNotThrow(()=>db.CreateSchema("Frank"));
+            Assert.DoesNotThrow(()=>db.CreateSchema("Frank"));
+            Assert.DoesNotThrow(()=>db.CreateSchema("[Frank]"));
 
             if (type == DatabaseType.MicrosoftSQLServer)
             {

--- a/Tests/FAnsiTests/Database/DatabaseLevelTests.cs
+++ b/Tests/FAnsiTests/Database/DatabaseLevelTests.cs
@@ -34,24 +34,20 @@ namespace FAnsiTests.Database
         {
             var db = GetTestDatabase(type);
 
-            Assert.DoesNotThrow(()=>db.CreateSchema("Frank"));
-            Assert.DoesNotThrow(()=>db.CreateSchema("Frank"));
+            Assert.DoesNotThrow(()=>db.CreateSchema("Fr ank"));
+            Assert.DoesNotThrow(()=>db.CreateSchema("Fr ank"));
 
-            if(type == DatabaseType.MicrosoftSQLServer)
-            {
-                Assert.DoesNotThrow(()=>db.CreateSchema("[Frank]"));
-                Assert.DoesNotThrow(()=>db.CreateSchema("[Frank]"));
-            }
+            db.Server.GetQuerySyntaxHelper().EnsureWrapped("Fr ank");
 
-            if (type == DatabaseType.MicrosoftSQLServer)
+            if (type == DatabaseType.MicrosoftSQLServer || type == DatabaseType.PostgreSql)
             {
                 var tbl = db.CreateTable("Heyyy",
-                    new[] {new DatabaseColumnRequest("fff", new DatabaseTypeRequest(typeof(string), 10))},"Frank");
+                    new[] {new DatabaseColumnRequest("fff", new DatabaseTypeRequest(typeof(string), 10))},"Fr ank");
 
                 Assert.IsTrue(tbl.Exists());
 
                 if(type == DatabaseType.MicrosoftSQLServer)
-                    Assert.AreEqual("Frank",tbl.Schema);
+                    Assert.AreEqual("Fr ank",tbl.Schema);
             }
         }
     }

--- a/Tests/FAnsiTests/Query/QuerySyntaxHelperTests.cs
+++ b/Tests/FAnsiTests/Query/QuerySyntaxHelperTests.cs
@@ -51,6 +51,17 @@ namespace FAnsiTests.Query
         }
         
         [TestCaseSource(typeof(All),nameof(All.DatabaseTypes))]
+        public void EnsureWrapped_MultipleCalls(DatabaseType dbType)
+        {
+            var syntax = new QuerySyntaxHelperFactory().Create(dbType);
+
+            string once = syntax.EnsureWrapped("ff");
+            string twice = syntax.EnsureWrapped(once);
+
+            Assert.AreEqual(once,twice);
+        }
+
+        [TestCaseSource(typeof(All),nameof(All.DatabaseTypes))]
         public void SyntaxHelperTest_GetRuntimeName_Impossible(DatabaseType t)
         {
             ImplementationManager.Load(new DirectoryInfo(TestContext.CurrentContext.TestDirectory));


### PR DESCRIPTION
Fix for CreateSchema (e.g. RoundHousE when spamming the method).

Bug was introduced in https://github.com/HicServices/FAnsiSql/commit/316420ab57b1944c41e53160fb729dea843e0991#diff-f1a615727862a5f6875ff0631e7c769dR236

```
-- Does NOT work
select * from sys.schemas where name = '[RoundHousE]'
```


```
-- Works
select * from sys.schemas where name = 'RoundHousE'
```