### PR TITLE
Feature/net7

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 7.0.x
     - name: Install Sql Server
       run: |
         wget -qO- https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -

--- a/Tests/FAnsiTests/FAnsiTests.csproj
+++ b/Tests/FAnsiTests/FAnsiTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <AssemblyTitle>FAnsiSqlTests</AssemblyTitle>
     <Product>FAnsiSqlTests</Product>
     <Copyright>Copyright ©  2019</Copyright>


### PR DESCRIPTION
- Build under SDK 7 not 6, run tests (only) under .Net 7 rather than 6