### PR TITLE
Postgres:ListDatabases - add default database to connection 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Bugfix for listing databases on Postgres server failing without specifying connection database
+
 ## [3.2.5] - 2024-06-07
 
 - Bugfix for resource lifetime in ListDatabasesAsync, add unit tests

--- a/FAnsiSql/Implementations/PostgreSql/PostgreSqlServerHelper.cs
+++ b/FAnsiSql/Implementations/PostgreSql/PostgreSqlServerHelper.cs
@@ -66,7 +66,7 @@ public sealed class PostgreSqlServerHelper : DiscoveredServerHelper
         //create a copy so as not to corrupt the original
         var b = new NpgsqlConnectionStringBuilder(builder.ConnectionString)
         {
-            Database = null,
+            Database = "postgres", //Use the default database, otherwise Npgsql will try to connect to a database with the same name as the user
             Timeout = 5
         };
 


### PR DESCRIPTION
Issue raised in RDMP - https://github.com/HicServices/RDMP/issues/1873
The issue appears as though when connection to a Postgres server, if no database is specified, it will Ngpsql will attempt to connect to a database with the same name as  the user.

This fix uses the default postgres database to connect to in order to enumerate the databases on the server