### PR TITLE
Remove Postgres DB List Database Mangling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Listing databases on Postgres now respects connection string database and timeout
+
 ## [3.2.5] - 2024-06-07
 
 - Bugfix for resource lifetime in ListDatabasesAsync, add unit tests

--- a/FAnsiSql/Discovery/DiscoveredColumn.cs
+++ b/FAnsiSql/Discovery/DiscoveredColumn.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using FAnsi.Discovery.QuerySyntax;
+﻿using FAnsi.Discovery.QuerySyntax;
 using FAnsi.Naming;
 using TypeGuesser;
 

--- a/FAnsiSql/Discovery/DiscoveredServerHelper.cs
+++ b/FAnsiSql/Discovery/DiscoveredServerHelper.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data.Common;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using System.Threading;

--- a/FAnsiSql/Implementations/PostgreSql/PostgreSqlServerHelper.cs
+++ b/FAnsiSql/Implementations/PostgreSql/PostgreSqlServerHelper.cs
@@ -33,7 +33,6 @@ public sealed class PostgreSqlServerHelper : DiscoveredServerHelper
     public override void CreateDatabase(DbConnectionStringBuilder builder, IHasRuntimeName newDatabaseName)
     {
         var b = (NpgsqlConnectionStringBuilder)GetConnectionStringBuilder(builder.ConnectionString);
-        b.Database = null;
 
         using var con = new NpgsqlConnection(b.ConnectionString);
         con.Open();

--- a/FAnsiSql/Implementations/PostgreSql/PostgreSqlServerHelper.cs
+++ b/FAnsiSql/Implementations/PostgreSql/PostgreSqlServerHelper.cs
@@ -37,25 +37,25 @@ public sealed class PostgreSqlServerHelper : DiscoveredServerHelper
 
         using var con = new NpgsqlConnection(b.ConnectionString);
         con.Open();
-        using var cmd = GetCommand($"CREATE DATABASE \"{newDatabaseName.GetRuntimeName()}\"",con);
+        using var cmd = GetCommand($"CREATE DATABASE \"{newDatabaseName.GetRuntimeName()}\"", con);
         cmd.CommandTimeout = CreateDatabaseTimeoutInSeconds;
         cmd.ExecuteNonQuery();
     }
 
     public override Dictionary<string, string> DescribeServer(DbConnectionStringBuilder builder) => throw new NotImplementedException();
 
-    public override string? GetExplicitUsernameIfAny(DbConnectionStringBuilder builder) => ((NpgsqlConnectionStringBuilder) builder).Username;
+    public override string? GetExplicitUsernameIfAny(DbConnectionStringBuilder builder) => ((NpgsqlConnectionStringBuilder)builder).Username;
 
-    public override string? GetExplicitPasswordIfAny(DbConnectionStringBuilder builder) => ((NpgsqlConnectionStringBuilder) builder).Password;
+    public override string? GetExplicitPasswordIfAny(DbConnectionStringBuilder builder) => ((NpgsqlConnectionStringBuilder)builder).Password;
 
     public override Version? GetVersion(DiscoveredServer server)
     {
         using var con = server.GetConnection();
         con.Open();
-        using var cmd = server.GetCommand("SHOW server_version",con);
+        using var cmd = server.GetCommand("SHOW server_version", con);
         using var r = cmd.ExecuteReader();
-        if(r.Read())
-            return r[0] == DBNull.Value ? null: CreateVersionFromString((string)r[0]);
+        if (r.Read())
+            return r[0] == DBNull.Value ? null : CreateVersionFromString((string)r[0]);
 
         return null;
     }
@@ -64,10 +64,10 @@ public sealed class PostgreSqlServerHelper : DiscoveredServerHelper
     public override IEnumerable<string> ListDatabases(DbConnectionStringBuilder builder)
     {
         //create a copy so as not to corrupt the original
+
         var b = new NpgsqlConnectionStringBuilder(builder.ConnectionString)
         {
-            Database = null,
-            Timeout = 5
+            Timeout = builder.TryGetValue("Timeout", out var timeout) ? (int)timeout : 5
         };
 
         using var con = new NpgsqlConnection(b.ConnectionString);
@@ -88,7 +88,7 @@ public sealed class PostgreSqlServerHelper : DiscoveredServerHelper
 
     public override DbDataAdapter GetDataAdapter(DbCommand cmd) => new NpgsqlDataAdapter((NpgsqlCommand)cmd);
 
-    public override DbCommandBuilder GetCommandBuilder(DbCommand cmd) => new NpgsqlCommandBuilder(new NpgsqlDataAdapter((NpgsqlCommand) cmd));
+    public override DbCommandBuilder GetCommandBuilder(DbCommand cmd) => new NpgsqlCommandBuilder(new NpgsqlDataAdapter((NpgsqlCommand)cmd));
 
     public override DbParameter GetParameter(string parameterName) => new NpgsqlParameter { ParameterName = parameterName };
 

--- a/Tests/FAnsiTests/CrossPlatformTests.cs
+++ b/Tests/FAnsiTests/CrossPlatformTests.cs
@@ -793,9 +793,6 @@ public sealed class CrossPlatformTests:DatabaseTests
         var database = GetTestDatabase(type);
 
         SqlConnection.ClearAllPools();
-        //var db = database.Server.ExpectDatabase(horribleTableName);
-        //if (db.Exists())
-        //    db.Drop();
         if (type == DatabaseType.PostgreSql)
             database.Server.CreateDatabase(horribleDatabaseName);
 

--- a/Tests/FAnsiTests/CrossPlatformTests.cs
+++ b/Tests/FAnsiTests/CrossPlatformTests.cs
@@ -793,9 +793,15 @@ public sealed class CrossPlatformTests:DatabaseTests
         var database = GetTestDatabase(type);
 
         SqlConnection.ClearAllPools();
+        //var db = database.Server.ExpectDatabase(horribleTableName);
+        //if (db.Exists())
+        //    db.Drop();
+        if (type == DatabaseType.PostgreSql)
+            database.Server.CreateDatabase(horribleDatabaseName);
 
         database = database.Server.ExpectDatabase(horribleDatabaseName);
-        database.Create(true);
+        if(type != DatabaseType.PostgreSql)
+            database.Create(true);
             
         SqlConnection.ClearAllPools();
 
@@ -918,9 +924,8 @@ public sealed class CrossPlatformTests:DatabaseTests
         AssertCanCreateDatabases();
 
         var database = GetTestDatabase(type);
-
+        database.Server.CreateDatabase(horribleDatabaseName);
         database = database.Server.ExpectDatabase(horribleDatabaseName);
-        database.Create(true);
         Assert.That(database.GetRuntimeName(), Is.EqualTo(horribleDatabaseName).IgnoreCase);
 
         try

--- a/Tests/FAnsiTests/DatabaseTests.cs
+++ b/Tests/FAnsiTests/DatabaseTests.cs
@@ -20,7 +20,7 @@ namespace FAnsiTests;
 [NonParallelizable]
 public class DatabaseTests
 {
-    protected readonly Dictionary<DatabaseType,string> TestConnectionStrings = [];
+    protected readonly Dictionary<DatabaseType, string> TestConnectionStrings = [];
 
     private bool _allowDatabaseCreation;
     private string _testScratchDatabase;
@@ -39,11 +39,11 @@ public class DatabaseTests
 
             var file = Path.Combine(TestContext.CurrentContext.TestDirectory, TestFilename);
 
-            Assert.That(File.Exists(file),"Could not find " + TestFilename);
+            Assert.That(File.Exists(file), "Could not find " + TestFilename);
 
             var doc = XDocument.Load(file);
 
-            var root = doc.Element("TestDatabases")??throw new Exception($"Missing element 'TestDatabases' in {TestFilename}");
+            var root = doc.Element("TestDatabases") ?? throw new Exception($"Missing element 'TestDatabases' in {TestFilename}");
 
             var settings = root.Element("Settings") ??
                            throw new Exception($"Missing element 'Settings' in {TestFilename}");
@@ -62,13 +62,22 @@ public class DatabaseTests
             {
                 var type = element.Element("DatabaseType")?.Value;
 
-                if(!Enum.TryParse(type, out DatabaseType databaseType))
+                if (!Enum.TryParse(type, out DatabaseType databaseType))
                     throw new Exception($"Could not parse DatabaseType {type}");
 
 
                 var constr = element.Element("ConnectionString")?.Value;
 
-                TestConnectionStrings.Add(databaseType,constr);
+                TestConnectionStrings.Add(databaseType, constr);
+            }
+            if (TestConnectionStrings.ContainsKey(DatabaseType.PostgreSql))
+            {
+                //make the postgres test DB if it doesn't exist
+                var testDB = GetTestDatabase(DatabaseType.PostgreSql);
+                if (!testDB.Server.DiscoverDatabases().ToList().Any(db => db.GetWrappedName().Contains(_testScratchDatabase)))
+                {
+                    testDB.Server.CreateDatabase(_testScratchDatabase);
+                }
             }
         }
         catch (Exception exception)
@@ -85,19 +94,19 @@ public class DatabaseTests
     }
     protected DiscoveredServer GetTestServer(DatabaseType type)
     {
-        if(!TestConnectionStrings.ContainsKey(type))
+        if (!TestConnectionStrings.ContainsKey(type))
             Assert.Inconclusive("No connection string configured for that server");
 
         return new DiscoveredServer(TestConnectionStrings[type], type);
     }
 
-    protected DiscoveredDatabase GetTestDatabase(DatabaseType type, bool cleanDatabase=true)
+    protected DiscoveredDatabase GetTestDatabase(DatabaseType type, bool cleanDatabase = true)
     {
         var server = GetTestServer(type);
         var db = server.ExpectDatabase(_testScratchDatabase);
 
-        if(!db.Exists())
-            if(_allowDatabaseCreation)
+        if (!db.Exists())
+            if (_allowDatabaseCreation)
                 db.Create();
             else
                 Assert.Inconclusive(
@@ -131,7 +140,7 @@ public class DatabaseTests
 
     protected void AssertCanCreateDatabases()
     {
-        if(!_allowDatabaseCreation)
+        if (!_allowDatabaseCreation)
             Assert.Inconclusive("Test cannot run when AllowDatabaseCreation is false");
     }
 
@@ -165,7 +174,7 @@ public class DatabaseTests
 
         foreach (DataRow row1 in dt1.Rows)
         {
-            var match = dt2.Rows.Cast<DataRow>().Any(row2=> dt1.Columns.Cast<DataColumn>().All(c => AreBasicallyEquals(row1[c.ColumnName], row2[c.ColumnName])));
+            var match = dt2.Rows.Cast<DataRow>().Any(row2 => dt1.Columns.Cast<DataColumn>().All(c => AreBasicallyEquals(row1[c.ColumnName], row2[c.ColumnName])));
             Assert.That(match, $"Couldn't find match for row:{string.Join(",", row1.ItemArray)}");
         }
 

--- a/Tests/FAnsiTests/DatabaseTests.cs
+++ b/Tests/FAnsiTests/DatabaseTests.cs
@@ -13,6 +13,7 @@ using FAnsi.Implementations.Oracle;
 using FAnsi.Implementations.MicrosoftSQL;
 using FAnsi.Implementations.PostgreSql;
 using NUnit.Framework;
+using NUnit.Framework.Internal;
 
 namespace FAnsiTests;
 
@@ -72,11 +73,10 @@ public class DatabaseTests
             }
             if (TestConnectionStrings.ContainsKey(DatabaseType.PostgreSql))
             {
-                //make the postgres test DB if it doesn't exist
-                var testDB = GetTestDatabase(DatabaseType.PostgreSql);
-                if (!testDB.Server.DiscoverDatabases().ToList().Any(db => db.GetWrappedName().Contains(_testScratchDatabase)))
+                var server = GetTestServer(DatabaseType.PostgreSql);
+                if (!server.DiscoverDatabases().ToList().Any(db => db.GetWrappedName().Contains(_testScratchDatabase)))
                 {
-                    testDB.Server.CreateDatabase(_testScratchDatabase);
+                    server.CreateDatabase(_testScratchDatabase);
                 }
             }
         }

--- a/Tests/FAnsiTests/DatabaseTests.cs
+++ b/Tests/FAnsiTests/DatabaseTests.cs
@@ -13,7 +13,6 @@ using FAnsi.Implementations.Oracle;
 using FAnsi.Implementations.MicrosoftSQL;
 using FAnsi.Implementations.PostgreSql;
 using NUnit.Framework;
-using NUnit.Framework.Internal;
 
 namespace FAnsiTests;
 
@@ -70,13 +69,12 @@ public class DatabaseTests
                 var constr = element.Element("ConnectionString")?.Value;
 
                 TestConnectionStrings.Add(databaseType, constr);
-            }
-            if (TestConnectionStrings.ContainsKey(DatabaseType.PostgreSql))
-            {
-                var server = GetTestServer(DatabaseType.PostgreSql);
-                if (!server.DiscoverDatabases().ToList().Any(db => db.GetWrappedName().Contains(_testScratchDatabase)))
+
+                // Make sure our scratch db exists for PostgreSQL
+                if (databaseType == DatabaseType.PostgreSql)
                 {
-                    server.CreateDatabase(_testScratchDatabase);
+                    var server = GetTestServer(DatabaseType.PostgreSql);
+                    if (server.DiscoverDatabases().All(db => db.GetWrappedName()?.Contains(_testScratchDatabase) != true)) server.CreateDatabase(_testScratchDatabase);
                 }
             }
         }

--- a/Tests/FAnsiTests/Table/CreateIndexTest.cs
+++ b/Tests/FAnsiTests/Table/CreateIndexTest.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Data;
-using System.Data.Common;
+﻿using System.Data;
 using FAnsi;
 using FAnsi.Discovery;
 using FAnsi.Exceptions;

--- a/Tests/FAnsiTests/Table/LongNamesTests.cs
+++ b/Tests/FAnsiTests/Table/LongNamesTests.cs
@@ -8,7 +8,7 @@ namespace FAnsiTests.Table;
 
 internal sealed class LongNamesTests : DatabaseTests
 {
-    [TestCaseSource(typeof(All),nameof(All.DatabaseTypes))]
+    [TestCaseSource(typeof(All), nameof(All.DatabaseTypes))]
     public void Test_LongTableName_CreateAndReadBack(DatabaseType dbType)
     {
         var db = GetTestDatabase(dbType);
@@ -16,7 +16,7 @@ internal sealed class LongNamesTests : DatabaseTests
         var tableName = new StringBuilder(db.Server.GetQuerySyntaxHelper().MaximumTableLength).Append('a', db.Server.GetQuerySyntaxHelper().MaximumTableLength).ToString();
         var columnName = new StringBuilder(db.Server.GetQuerySyntaxHelper().MaximumColumnLength).Append('b', db.Server.GetQuerySyntaxHelper().MaximumColumnLength).ToString();
 
-        var tbl = db.CreateTable(tableName,[new DatabaseColumnRequest(columnName,new DatabaseTypeRequest(typeof(string),100))]);
+        var tbl = db.CreateTable(tableName, [new DatabaseColumnRequest(columnName, new DatabaseTypeRequest(typeof(string), 100))]);
 
         Assert.Multiple(() =>
         {
@@ -29,7 +29,7 @@ internal sealed class LongNamesTests : DatabaseTests
         Assert.That(col.GetRuntimeName(), Is.EqualTo(columnName).IgnoreCase);
     }
 
-    [TestCaseSource(typeof(All),nameof(All.DatabaseTypes))]
+    [TestCaseSource(typeof(All), nameof(All.DatabaseTypes))]
     public void Test_LongDatabaseNames_CreateAndReadBack(DatabaseType dbType)
     {
         AssertCanCreateDatabases();
@@ -40,9 +40,11 @@ internal sealed class LongNamesTests : DatabaseTests
 
         for (var i = 0; i < db.Server.GetQuerySyntaxHelper().MaximumDatabaseLength; i++)
             sb.Append('a');
-
+        if (dbType == DatabaseType.PostgreSql)
+            db.Server.CreateDatabase(sb.ToString());
         var db2 = db.Server.ExpectDatabase(sb.ToString());
-        db2.Create(true);
+        if (dbType != DatabaseType.PostgreSql)
+            db2.Create(true);
 
         Assert.Multiple(() =>
         {

--- a/Tests/FAnsiTests/TestDatabases-github.xml
+++ b/Tests/FAnsiTests/TestDatabases-github.xml
@@ -18,6 +18,6 @@
   </TestDatabase>
   <TestDatabase>
     <DatabaseType>PostgreSql</DatabaseType>
-    <ConnectionString>User ID=postgres;Password=pgpass4291;Host=127.0.0.1;Port=5432</ConnectionString>
+    <ConnectionString>User ID=postgres;Password=pgpass4291;Host=127.0.0.1;Port=5432;Database=postgres</ConnectionString>
   </TestDatabase>
 </TestDatabases>


### PR DESCRIPTION
Update to use whatever the postgres connection string wants as the connection db when listing databases, rather than set it to null